### PR TITLE
Fix mobile menu overlay text overlap

### DIFF
--- a/about.html
+++ b/about.html
@@ -26,7 +26,7 @@
   .nav-home{display:flex;align-items:center}
   .nav-cta{background:var(--sage)!important;color:var(--white)!important;padding:10px 24px!important;letter-spacing:0.08em!important;transition:background 0.2s!important}
   .nav-cta:hover{background:var(--stone)!important}
-  .mobile-toggle{display:none;background:none;border:none;cursor:pointer;width:28px;height:20px;position:relative;z-index:101}
+  .mobile-toggle{display:none;background:none;border:none;cursor:pointer;width:28px;height:20px;position:relative;z-index:201}
   .mobile-toggle span{display:block;width:100%;height:1.5px;background:var(--charcoal);transition:0.3s;position:absolute;left:0}
   .mobile-toggle span:nth-child(1){top:0}
   .mobile-toggle span:nth-child(2){top:50%;transform:translateY(-50%)}
@@ -86,8 +86,9 @@
     .approach-inner{grid-template-columns:1fr;gap:48px}
     .nav-links{display:none}
     .mobile-toggle{display:block}
-    .nav-links.open{display:flex;flex-direction:column;position:fixed;top:0;left:0;right:0;bottom:0;background:var(--cream);z-index:100;justify-content:center;align-items:center;gap:28px;padding:80px 28px}
+    .nav-links.open{display:flex;flex-direction:column;position:fixed;top:0;left:0;right:0;bottom:0;background:var(--cream);z-index:200;justify-content:center;align-items:center;gap:28px;padding:80px 28px}
     .nav-links.open a{font-size:16px}
+    body.menu-open{overflow:hidden}
   }
   @media(max-width:480px){
     footer{flex-direction:column;gap:8px;text-align:center}
@@ -175,8 +176,8 @@
   window.addEventListener('scroll',()=>{nav.classList.toggle('scrolled',window.scrollY>60)});
   const toggle=document.getElementById('mobileToggle');
   const links=document.getElementById('navLinks');
-  toggle.addEventListener('click',()=>{toggle.classList.toggle('open');links.classList.toggle('open')});
-  links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',()=>{toggle.classList.remove('open');links.classList.remove('open')})});
+  toggle.addEventListener('click',()=>{toggle.classList.toggle('open');links.classList.toggle('open');document.body.classList.toggle('menu-open')});
+  links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',()=>{toggle.classList.remove('open');links.classList.remove('open');document.body.classList.remove('menu-open')})});
   const obs=new IntersectionObserver(entries=>{entries.forEach(entry=>{if(entry.isIntersecting){entry.target.classList.add('on');obs.unobserve(entry.target)}})},{threshold:0.08,rootMargin:'0px 0px -40px 0px'});
   document.querySelectorAll('.reveal').forEach(el=>obs.observe(el));
 </script>

--- a/faq.html
+++ b/faq.html
@@ -62,7 +62,7 @@
   .nav-cta:hover { background: var(--stone) !important; }
   .mobile-toggle {
     display: none; background: none; border: none; cursor: pointer;
-    width: 28px; height: 20px; position: relative; z-index: 101;
+    width: 28px; height: 20px; position: relative; z-index: 201;
   }
   .mobile-toggle span {
     display: block; width: 100%; height: 1.5px;
@@ -190,11 +190,12 @@
     .nav-links.open {
       display: flex; flex-direction: column;
       position: fixed; top: 0; left: 0; right: 0; bottom: 0;
-      background: var(--cream); z-index: 100;
+      background: var(--cream); z-index: 200;
       justify-content: center; align-items: center;
       gap: 28px; padding: 80px 28px;
     }
     .nav-links.open a { font-size: 16px; }
+    body.menu-open { overflow: hidden; }
     .faq-question { font-size: 19px; }
   }
   @media (max-width: 480px) {
@@ -365,8 +366,8 @@
   window.addEventListener('scroll', () => { nav.classList.toggle('scrolled', window.scrollY > 60); });
   const toggle = document.getElementById('mobileToggle');
   const links = document.getElementById('navLinks');
-  toggle.addEventListener('click', () => { toggle.classList.toggle('open'); links.classList.toggle('open'); });
-  links.querySelectorAll('a').forEach(a => { a.addEventListener('click', () => { toggle.classList.remove('open'); links.classList.remove('open'); }); });
+  toggle.addEventListener('click', () => { toggle.classList.toggle('open'); links.classList.toggle('open'); document.body.classList.toggle('menu-open'); });
+  links.querySelectorAll('a').forEach(a => { a.addEventListener('click', () => { toggle.classList.remove('open'); links.classList.remove('open'); document.body.classList.remove('menu-open'); }); });
 
   // FAQ accordion
   document.querySelectorAll('.faq-question').forEach(btn => {

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
 
   .mobile-toggle {
     display: none; background: none; border: none; cursor: pointer;
-    width: 28px; height: 20px; position: relative; z-index: 101;
+    width: 28px; height: 20px; position: relative; z-index: 201;
   }
   .mobile-toggle span {
     display: block; width: 100%; height: 1.5px;
@@ -395,11 +395,12 @@
     .nav-links.open {
       display: flex; flex-direction: column;
       position: fixed; top: 0; left: 0; right: 0; bottom: 0;
-      background: var(--cream); z-index: 100;
+      background: var(--cream); z-index: 200;
       justify-content: center; align-items: center;
       gap: 28px; padding: 80px 28px;
     }
     .nav-links.open a { font-size: 16px; }
+    body.menu-open { overflow: hidden; }
   }
   @media (max-width: 480px) {
     .hero h1 { font-size: 36px; }
@@ -612,11 +613,13 @@
   toggle.addEventListener('click', () => {
     toggle.classList.toggle('open');
     links.classList.toggle('open');
+    document.body.classList.toggle('menu-open');
   });
   links.querySelectorAll('a').forEach(a => {
     a.addEventListener('click', () => {
       toggle.classList.remove('open');
       links.classList.remove('open');
+      document.body.classList.remove('menu-open');
     });
   });
 

--- a/resources.html
+++ b/resources.html
@@ -26,7 +26,7 @@
   .nav-home{display:flex;align-items:center}
   .nav-cta{background:var(--sage)!important;color:var(--white)!important;padding:10px 24px!important;letter-spacing:0.08em!important;transition:background 0.2s!important}
   .nav-cta:hover{background:var(--stone)!important}
-  .mobile-toggle{display:none;background:none;border:none;cursor:pointer;width:28px;height:20px;position:relative;z-index:101}
+  .mobile-toggle{display:none;background:none;border:none;cursor:pointer;width:28px;height:20px;position:relative;z-index:201}
   .mobile-toggle span{display:block;width:100%;height:1.5px;background:var(--charcoal);transition:0.3s;position:absolute;left:0}
   .mobile-toggle span:nth-child(1){top:0}
   .mobile-toggle span:nth-child(2){top:50%;transform:translateY(-50%)}
@@ -74,8 +74,9 @@
     .resources-grid{grid-template-columns:1fr}
     .nav-links{display:none}
     .mobile-toggle{display:block}
-    .nav-links.open{display:flex;flex-direction:column;position:fixed;top:0;left:0;right:0;bottom:0;background:var(--cream);z-index:100;justify-content:center;align-items:center;gap:28px;padding:80px 28px}
+    .nav-links.open{display:flex;flex-direction:column;position:fixed;top:0;left:0;right:0;bottom:0;background:var(--cream);z-index:200;justify-content:center;align-items:center;gap:28px;padding:80px 28px}
     .nav-links.open a{font-size:16px}
+    body.menu-open{overflow:hidden}
   }
   @media(max-width:480px){
     .resource-card{padding:36px 24px}
@@ -169,8 +170,8 @@
   window.addEventListener('scroll',()=>{nav.classList.toggle('scrolled',window.scrollY>60)});
   const toggle=document.getElementById('mobileToggle');
   const links=document.getElementById('navLinks');
-  toggle.addEventListener('click',()=>{toggle.classList.toggle('open');links.classList.toggle('open')});
-  links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',()=>{toggle.classList.remove('open');links.classList.remove('open')})});
+  toggle.addEventListener('click',()=>{toggle.classList.toggle('open');links.classList.toggle('open');document.body.classList.toggle('menu-open')});
+  links.querySelectorAll('a').forEach(a=>{a.addEventListener('click',()=>{toggle.classList.remove('open');links.classList.remove('open');document.body.classList.remove('menu-open')})});
   const obs=new IntersectionObserver(entries=>{entries.forEach(entry=>{if(entry.isIntersecting){entry.target.classList.add('on');obs.unobserve(entry.target)}})},{threshold:0.08,rootMargin:'0px 0px -40px 0px'});
   document.querySelectorAll('.reveal').forEach(el=>obs.observe(el));
 </script>

--- a/services.html
+++ b/services.html
@@ -62,7 +62,7 @@
   .nav-cta:hover { background: var(--stone) !important; }
   .mobile-toggle {
     display: none; background: none; border: none; cursor: pointer;
-    width: 28px; height: 20px; position: relative; z-index: 101;
+    width: 28px; height: 20px; position: relative; z-index: 201;
   }
   .mobile-toggle span {
     display: block; width: 100%; height: 1.5px;
@@ -251,11 +251,12 @@
     .nav-links.open {
       display: flex; flex-direction: column;
       position: fixed; top: 0; left: 0; right: 0; bottom: 0;
-      background: var(--cream); z-index: 100;
+      background: var(--cream); z-index: 200;
       justify-content: center; align-items: center;
       gap: 28px; padding: 80px 28px;
     }
     .nav-links.open a { font-size: 16px; }
+    body.menu-open { overflow: hidden; }
   }
   @media (max-width: 480px) {
     .session-card, .fee-card { padding: 36px 24px; }
@@ -389,8 +390,8 @@
   window.addEventListener('scroll', () => { nav.classList.toggle('scrolled', window.scrollY > 60); });
   const toggle = document.getElementById('mobileToggle');
   const links = document.getElementById('navLinks');
-  toggle.addEventListener('click', () => { toggle.classList.toggle('open'); links.classList.toggle('open'); });
-  links.querySelectorAll('a').forEach(a => { a.addEventListener('click', () => { toggle.classList.remove('open'); links.classList.remove('open'); }); });
+  toggle.addEventListener('click', () => { toggle.classList.toggle('open'); links.classList.toggle('open'); document.body.classList.toggle('menu-open'); });
+  links.querySelectorAll('a').forEach(a => { a.addEventListener('click', () => { toggle.classList.remove('open'); links.classList.remove('open'); document.body.classList.remove('menu-open'); }); });
   const obs = new IntersectionObserver(entries => {
     entries.forEach(entry => {
       if (entry.isIntersecting) { entry.target.classList.add('on'); obs.unobserve(entry.target); }

--- a/workshop.html
+++ b/workshop.html
@@ -62,7 +62,7 @@
   .nav-cta:hover { background: var(--stone) !important; }
   .mobile-toggle {
     display: none; background: none; border: none; cursor: pointer;
-    width: 28px; height: 20px; position: relative; z-index: 101;
+    width: 28px; height: 20px; position: relative; z-index: 201;
   }
   .mobile-toggle span {
     display: block; width: 100%; height: 1.5px;
@@ -250,11 +250,12 @@
     .nav-links.open {
       display: flex; flex-direction: column;
       position: fixed; top: 0; left: 0; right: 0; bottom: 0;
-      background: var(--cream); z-index: 100;
+      background: var(--cream); z-index: 200;
       justify-content: center; align-items: center;
       gap: 28px; padding: 80px 28px;
     }
     .nav-links.open a { font-size: 16px; }
+    body.menu-open { overflow: hidden; }
   }
   @media (max-width: 480px) {
     .included-card, .how-item { padding: 32px 24px; }
@@ -425,8 +426,8 @@
   window.addEventListener('scroll', () => { nav.classList.toggle('scrolled', window.scrollY > 60); });
   const toggle = document.getElementById('mobileToggle');
   const links = document.getElementById('navLinks');
-  toggle.addEventListener('click', () => { toggle.classList.toggle('open'); links.classList.toggle('open'); });
-  links.querySelectorAll('a').forEach(a => { a.addEventListener('click', () => { toggle.classList.remove('open'); links.classList.remove('open'); }); });
+  toggle.addEventListener('click', () => { toggle.classList.toggle('open'); links.classList.toggle('open'); document.body.classList.toggle('menu-open'); });
+  links.querySelectorAll('a').forEach(a => { a.addEventListener('click', () => { toggle.classList.remove('open'); links.classList.remove('open'); document.body.classList.remove('menu-open'); }); });
   const obs = new IntersectionObserver(entries => {
     entries.forEach(entry => {
       if (entry.isIntersecting) { entry.target.classList.add('on'); obs.unobserve(entry.target); }


### PR DESCRIPTION
## Summary
- Fixed mobile menu z-index from 100 to 200 so the fullscreen overlay properly covers the nav bar content, preventing text from showing through
- Increased hamburger button z-index from 101 to 201 so it remains clickable above the menu overlay
- Added `body.menu-open` class to prevent background scrolling when mobile menu is open
- Applied fix across all 6 HTML pages (index, about, services, faq, workshop, resources)

## Test plan
- [ ] Open site on mobile device or browser dev tools in mobile view
- [ ] Tap hamburger menu — menu should open fullscreen with no text overlap
- [ ] Page behind should not scroll while menu is open
- [ ] Tapping a menu link should close menu and navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)